### PR TITLE
🔒 fix(github workflows): replace VERCEL_TOKEN with VERCEL_BACKEND_TOK…

### DIFF
--- a/.github/Production.yml
+++ b/.github/Production.yml
@@ -18,8 +18,8 @@ jobs:
           cache: ''
       # - run: npm cache --force clean && npm install --force node-sass
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_BACKEND_TOKEN }}
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_BACKEND_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_BACKEND_TOKEN }}

--- a/.github/preview.yaml
+++ b/.github/preview.yaml
@@ -18,8 +18,8 @@ jobs:
           cache: ''
       # - run: npm cache --force clean && npm install --force node-sass
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_BACKEND_TOKEN }}
       - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --token=${{ secrets.VERCEL_BACKEND_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_BACKEND_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+.vercel


### PR DESCRIPTION
…EN in Production.yml and preview.yaml

🔧 chore(gitignore): add .vercel to .gitignore

The VERCEL_TOKEN was replaced with VERCEL_BACKEND_TOKEN in the GitHub workflows to enhance security. The new token is more specific to backend operations, reducing the risk of unauthorized access to other Vercel services.

The .vercel directory was added to .gitignore to prevent unnecessary files from being tracked in the repository. This directory is created by Vercel CLI and contains deployment-related data that should not be version controlled.