### PR TITLE
🔧 chore(package.json): add generate:schema script to prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "prebuild": "rimraf dist",
+    "prebuild": "npm run generate:schema && rimraf dist",
+    "generate:schema": "nest build && nest start --schema ./src/graphql/schema.gql",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,7 +6,7 @@ import { AppService } from './app.service';
 import { MercuriusDriver, MercuriusDriverConfig } from '@nestjs/mercurius';
 import { PubsubModule } from './graphql/pubsub/pubsub.module';
 import { PubSub } from './graphql/pubsub/pubsub';
-import { join } from 'path';
+
 import { SampleResolver } from './graphql/sample.resolver';
 
 @Module({
@@ -16,7 +16,7 @@ import { SampleResolver } from './graphql/sample.resolver';
       driver: MercuriusDriver,
       useFactory: (pubsub: PubSub): MercuriusDriverConfig => {
         return {
-          autoSchemaFile: join(process.cwd(), 'src/graphql/schema.gql'),
+          autoSchemaFile: true,
           subscription: {
             pubsub: pubsub,
           },


### PR DESCRIPTION
🔧 chore(app.module.ts): set autoSchemaFile to true and remove unused import

The generate:schema script was added to the prebuild script in package.json to ensure that the GraphQL schema is generated before each build. This ensures that the latest schema is always used during the build process.

In app.module.ts, the autoSchemaFile option was set to true to enable automatic schema generation. This change simplifies the configuration and ensures that the schema is always up-to-date. The unused 'join' import was also removed to clean up the code.